### PR TITLE
Add tabs for code samples

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -33,6 +33,10 @@ No, seriously.  With Sapling, all data is handled by its special and powerful dy
 
 Say you then want to show a list of the reviews that have been posted.  This is also super easy.  By default, Sapling uses the [Nunjucks](https://mozilla.github.io/nunjucks/) templating language, with a few custom tags to make things easier.
 
+<!-- tabs:start -->
+
+#### **Nunjucks**
+
 ```nunjucks
 {% get reviews = '/data/reviews' %}
 
@@ -41,6 +45,29 @@ Say you then want to show a list of the reviews that have been posted.  This is 
 <p>{{ review.content }}</p>
 {% endfor %}
 ```
+
+#### **Handlebars**
+
+```handlebars
+{{ get 'posts' from '/data/posts' as 'admin' }}
+
+{{#each posts}}
+<h2>{{ this.title }}</h2>
+<p>{{ this.content }}</p>
+{{/each}}
+```
+
+#### **Pug**
+
+```pug
+- var posts = get('/data/posts', 'admin')
+
+each post in posts
+	h2= post.title
+	p= post.content
+```
+
+<!-- tabs:end -->
 
 The `set` tag fetches the reviews that have been posted with the form above, and the `for` loop below goes through each review, and displays the fields that were defined in the form.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -35,7 +35,7 @@ The function will be passed five parameters;
 An example hook file might look like this;
 
 ```js
-export default function(app, req, res, data, next) {
+export default (app, req, res, data, next) => {
     // Do stuff here
 
     next(app, req, res, data);
@@ -52,7 +52,7 @@ Each hook will be passed a callback function as the fifth parameter.  If you'd l
 If you prefer not to let Sapling do its thing after your hook, you can ignore the callback, and handle the response yourself with the `res` object;
 
 ```js
-export default function(app, req, res, data, next) {
+export default (app, req, res, data, next) => {
     // Do stuff here
 
     res.send(200);
@@ -70,7 +70,7 @@ You can use it to send JSON data (either as a JS object literal or as a string);
 ```js
 import Response from "@sapling/sapling/lib/Response.js";
 
-export default function(app, req, res, data, next) {
+export default (app, req, res, data, next) => {
     new Response(app, req, res, null, [{"foo": "bar"}]);
 };
 ```
@@ -80,7 +80,7 @@ To send parsed HTML;
 ```js
 import Response from "@sapling/sapling/lib/Response.js";
 
-export default function(app, req, res, data, next) {
+export default (app, req, res, data, next) => {
     new Response(app, req, res, null, "<strong>Hello</strong>");
 };
 ```
@@ -91,7 +91,7 @@ Or, to send an error:
 import Response from "@sapling/sapling/lib/Response.js";
 import SaplingError from "@sapling/sapling/lib/SaplingError.js";
 
-export default function(app, req, res, data, next) {
+export default (app, req, res, data, next) => {
     new Response(app, req, res, new SaplingError(err));
 };
 ```

--- a/docs/views.md
+++ b/docs/views.md
@@ -31,13 +31,40 @@ The `get` tag will fetch data from a valid [data API](/data) call and expose it 
 
 For instance:
 
+<!-- tabs:start -->
+
+#### **Nunjucks**
+
 ```nunjucks
 {% get reviews = '/data/reviews' %}
-    
+
 {% for review in reviews %}
 <h2>{{ review.title }}</h2>
 <p>{{ review.content }}</p>
 {% endfor %}
 ```
+
+#### **Handlebars**
+
+```handlebars
+{{ get 'posts' from '/data/posts' as 'admin' }}
+
+{{#each posts}}
+<h2>{{ this.title }}</h2>
+<p>{{ this.content }}</p>
+{{/each}}
+```
+
+#### **Pug**
+
+```pug
+- var posts = get('/data/posts', 'admin')
+
+each post in posts
+	h2= post.title
+	p= post.content
+```
+
+<!-- tabs:end -->
 
 The `get` tag gets the list of reviews from `/data/reviews`, and exposes it in a variable called `reviews`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "docsify": "^4.12.2",
         "docsify-copy-code": "^2.1.1",
         "docsify-pagination": "^2.6.2",
+        "docsify-tabs": "^1.5.2",
         "docsify-themeable": "^0.8.6",
         "inline-svg": "^2.2.3",
         "laravel-mix": "^6.0.43",
@@ -4134,6 +4135,11 @@
         "component-matches-selector": "^0.1.6",
         "component-query": "0.0.3"
       }
+    },
+    "node_modules/docsify-tabs": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/docsify-tabs/-/docsify-tabs-1.5.2.tgz",
+      "integrity": "sha512-ExVJ2XdO7oFrlGcouYnQBaKdHWqV5P4SYqLPCIoMzfi8uk3ku3JzCNDHUVRy1ALLyRpNwmcUSP5YLBl0plaQaA=="
     },
     "node_modules/docsify-themeable": {
       "version": "0.8.6",
@@ -16973,6 +16979,11 @@
         "component-matches-selector": "^0.1.6",
         "component-query": "0.0.3"
       }
+    },
+    "docsify-tabs": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/docsify-tabs/-/docsify-tabs-1.5.2.tgz",
+      "integrity": "sha512-ExVJ2XdO7oFrlGcouYnQBaKdHWqV5P4SYqLPCIoMzfi8uk3ku3JzCNDHUVRy1ALLyRpNwmcUSP5YLBl0plaQaA=="
     },
     "docsify-themeable": {
       "version": "0.8.6",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "docsify": "^4.12.2",
     "docsify-copy-code": "^2.1.1",
     "docsify-pagination": "^2.6.2",
+    "docsify-tabs": "^1.5.2",
     "docsify-themeable": "^0.8.6",
     "inline-svg": "^2.2.3",
     "laravel-mix": "^6.0.43",

--- a/src/js/docs.js
+++ b/src/js/docs.js
@@ -6,6 +6,16 @@ import 'docsify-pagination';
 import 'docsify-copy-code';
 import 'docsify-tabs';
 
+
+/* Language highlighting */
+
+import 'prismjs/components/prism-bash.js';
+import 'prismjs/components/prism-handlebars.js';
+import 'prismjs/components/prism-http.js';
+import 'prismjs/components/prism-json.js';
+import 'prismjs/components/prism-pug.js';
+import 'prismjs/components/prism-twig.js';
+
 window.$docsify = Object.assign({}, window.$docsify, {
 	name: 'Sapling',
 	logo: '../images/logo.svg',
@@ -26,19 +36,9 @@ window.$docsify = Object.assign({}, window.$docsify, {
 		sync: true,
 		theme: 'material',
 		tabComments: false,
-		tabHeadings: true
-	}
+		tabHeadings: true,
+	},
 });
-
-
-/* Language highlighting */
-
-import 'prismjs/components/prism-bash.js';
-import 'prismjs/components/prism-handlebars.js';
-import 'prismjs/components/prism-http.js';
-import 'prismjs/components/prism-json.js';
-import 'prismjs/components/prism-pug.js';
-import 'prismjs/components/prism-twig.js';
 
 window.Prism.languages.nunjucks = window.Prism.languages.twig;
 window.Prism.languages.env = window.Prism.languages.bash;

--- a/src/js/docs.js
+++ b/src/js/docs.js
@@ -1,15 +1,12 @@
+/* Docsify setup */
+
 import 'docsify';
 import 'docsify-themeable';
 import 'docsify-pagination';
 import 'docsify-copy-code';
+import 'docsify-tabs';
 
-import 'prismjs/components/prism-bash.js';
-import 'prismjs/components/prism-http.js';
-import 'prismjs/components/prism-json.js';
-import 'prismjs/components/prism-twig.js';
-
-
-window.$docsify = {
+window.$docsify = Object.assign({}, window.$docsify, {
 	name: 'Sapling',
 	logo: '../images/logo.svg',
 	repo: 'saplingjs/sapling',
@@ -24,7 +21,24 @@ window.$docsify = {
 		crossChapter: true,
 		crossChapterText: false,
 	},
-};
+	tabs: {
+		persist: true,
+		sync: true,
+		theme: 'material',
+		tabComments: false,
+		tabHeadings: true
+	}
+});
+
+
+/* Language highlighting */
+
+import 'prismjs/components/prism-bash.js';
+import 'prismjs/components/prism-handlebars.js';
+import 'prismjs/components/prism-http.js';
+import 'prismjs/components/prism-json.js';
+import 'prismjs/components/prism-pug.js';
+import 'prismjs/components/prism-twig.js';
 
 window.Prism.languages.nunjucks = window.Prism.languages.twig;
 window.Prism.languages.env = window.Prism.languages.bash;

--- a/src/stylus/docs.styl
+++ b/src/stylus/docs.styl
@@ -45,6 +45,14 @@ body
 			white-space nowrap
 
 
+.docsify-tabs__tab
+	cursor pointer
+	border-radius 0 !important
+
+.docsify-tabs--classic:before
+	margin-right 4px
+
+
 :root
 	--base-font-size             16px
 	--base-color                 $grey-dark
@@ -73,6 +81,8 @@ body
 	--sidebar-nav-pagelink-background-image--active   url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11.2' height='7' viewBox='0 0 11.2 7'%3E%3Cpath d='M1.5 1.5l4.1 4 4.1-4' stroke-width='1.5' stroke='%234dcf89' fill='none' stroke-linecap='square' stroke-linejoin='miter' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E")
 	--sidebar-nav-pagelink-background-image--collapse url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='7' height='11.2' viewBox='0 0 7 11.2'%3E%3Cpath d='M1.5 1.5l4 4.1 -4 4.1' stroke-width='1.5' stroke='%234dcf89' fill='none' stroke-linecap='square' stroke-linejoin='miter' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E")
 	--sidebar-nav-pagelink-background-image--loaded   url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11.2' height='7' viewBox='0 0 11.2 7'%3E%3Cpath d='M1.5 1.5l4.1 4 4.1-4' stroke-width='1.5' stroke='%234dcf89' fill='none' stroke-linecap='square' stroke-linejoin='miter' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E")
+
+	--docsifytabs-border-radius-px 8px
 
 @media (prefers-color-scheme dark)
 	:root
@@ -106,6 +116,9 @@ body
 		--code-theme-keyword            lighten($blue, 50%)
 		--code-theme-operator           lighten($yellow, 30%)
 		--copycode-background           lighten($dark-bg, 20%)
+
+		--docsifytabs-tab-background    darken($dark-bg, 10%)
+		--docsifytabs-border-color      lighten($dark-bg, 10%)
 
 
 @media screen and (max-width: 640px)


### PR DESCRIPTION
Implement tabs for code samples in different markup languages (Nunjucks, Handlebars, Pug).

Also fixes the Docsify plugin loading that apparently broke in #59

Closes #138 